### PR TITLE
Adds Clipanion

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ etc.
 
 ## [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 
+- [Clipanion](https://mael.dev/clipanion) : Official CLI framework powering both the Yarn CLI - one of the most complex command-line tool in the ecosystem - and small internal scripts. Clipanion is designed with type safety in mind, and leverages a syntax as idiomatic as possible to avoid cluttering your code with boilerplate.
+
 - [Oclif](https://github.com/oclif/oclif) : Oclif is a framework for building CLIs in Node.js. This framework was built out of the Heroku CLI but generalized to build any custom CLI. It's designed both for single-file CLIs with a few flag options, or for very complex CLIs that have subcommands (like git or heroku).
 
 - [Commander.js](https://github.com/tj/commander.js/) : The complete solution for node.js command-line interfaces.


### PR DESCRIPTION
Hi, I saw Clipanion isn't listed so I added it there. I wasn't sure which link you'd prefer: the [documentation website](https://mael.dev/clipanion), or the [repo](https://github.com/arcanis/clipanion)?