### PR TITLE
Replace TUI with Ratatui (a maintained fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ etc.
 
 - [Clap](https://github.com/clap-rs/clap) : A full featured, fast Command Line Argument Parser for Rust.
 
-- [TUI](https://github.com/fdehau/tui-rs) : Build terminal user interfaces and dashboards using Rust.
+- [Ratatui]((https://github.com/ratatui-org/ratatui)) : Build terminal user interfaces and dashboards using Rust.
 
 - [StructOpt](https://github.com/TeXitoi/structopt) : Parse command line arguments by defining a struct.
 


### PR DESCRIPTION
When I opened the TUI repo (https://github.com/fdehau/tui-rs) I noticed, that TUI is no longer maintained as of August 2023 and redirects you to a maintained fork called Ratatui (https://github.com/ratatui-org/ratatui).